### PR TITLE
Precompile the package and increase Julia requirement to 0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.4
+julia 0.5

--- a/src/PiBBP.jl
+++ b/src/PiBBP.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 """
 A toy Julia implementation of [Bailey-Borwein-Plouffe (BBP) alogithm](http://www.davidhbailey.com/dhbpapers/bbp-alg.pdf) for computation
 of hexadecimal digits of Pi.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,7 +17,5 @@ using Base.Test
 # It actually computes fractional part of $\pi$.
 #
 
-ds = pmap(digpi, 0:14)
-z  = sum(j -> ds[j] / 16^j, 1:length(ds))
-
-@test_approx_eq Float64(pi - 3.) z
+@test pi - (3 + sum(digpi(n) / 16^(n+1) for n in 0:14)) ≈ 0
+@test pi - (3 + sum(digpi(n) / big(16)^(n+1) for n in 0:64)) ≈ 0


### PR DESCRIPTION
Julia 0.4 is no more supported.  In addition

* explicitly specify the tested version on Travis (this is nowadays preferred to use a generic `release` target version)
* precompile the package
* use generator to more easily test the result
* test result also against `BigFloat`, for higher precision